### PR TITLE
Feature/shallow copies of images in layers (#235)

### DIFF
--- a/src/stackTools/fusionRenderer.js
+++ b/src/stackTools/fusionRenderer.js
@@ -31,9 +31,9 @@ export default class FusionRenderer {
         const currentLayerId = this.layerIds[0];
         const layer = cornerstone.getLayer(element, currentLayerId);
 
-        layer.image = image;
+        layer.image = Object.assign({}, image);
       } else {
-        const layerId = cornerstone.addLayer(element, image, baseImageObject.options);
+        const layerId = cornerstone.addLayer(element, Object.assign({}, image), baseImageObject.options);
 
         this.layerIds.push(layerId);
       }
@@ -58,9 +58,9 @@ export default class FusionRenderer {
             const currentLayerId = this.layerIds[layerIndex];
             const layer = cornerstone.getLayer(element, currentLayerId);
 
-            layer.image = image;
+            layer.image = Object.assign({}, image);
           } else {
-            const layerId = cornerstone.addLayer(element, image, imgObj.options);
+            const layerId = cornerstone.addLayer(element, Object.assign({}, image), imgObj.options);
 
             this.layerIds.push(layerId);
           }


### PR DESCRIPTION
* Use shallow copies of images in layers, to prevent the function convertImageToFalseColorImage() from altering original images.

* Object.assign() instead of $.extend()